### PR TITLE
fix: use 0 if entry.bufnr is nil

### DIFF
--- a/lua/telescope/_extensions/tele_tabby.lua
+++ b/lua/telescope/_extensions/tele_tabby.lua
@@ -120,7 +120,7 @@ local function make_entry(opts)
     -- but showing a window has an edited buffer is useful
     -- ]]
     local hidden = entry.info.hidden == 1 and 'h' or 'a'
-    local readonly = vim.api.nvim_buf_get_option(entry.bufnr, 'readonly') and '=' or ' '
+    local readonly = vim.api.nvim_buf_get_option(entry.bufnr or 0, 'readonly') and '=' or ' '
     local changed = entry.info.changed == 1 and '+' or ' '
     local indicator = entry.windownr .. hidden .. readonly .. changed
 


### PR DESCRIPTION
From neovim 0.7.0, neovim does not implicitly convert nil to 0 when
using nil as API arguments. This fix the breakage.

Related: neovim#16745